### PR TITLE
add for_each_edge to LS_CSR

### DIFF
--- a/libgalois/include/galois/graphs/LS_LC_CSR_Graph.h
+++ b/libgalois/include/galois/graphs/LS_LC_CSR_Graph.h
@@ -227,6 +227,20 @@ public:
   }
 
   /*
+   * Iterates over the outgoing edges, calling the callback with the
+   * VertexTopologyID of each edge.
+   */
+  template <typename Callback>
+  void for_each_edge(VertexTopologyID vertex, Callback const& callback) {
+    auto const& vertex_meta = m_vertices[vertex];
+    EdgeMetadata const* begin =
+        &getEdgeMetadata(vertex_meta.buffer, vertex_meta.begin);
+    for (uint64_t i = 0; i < vertex_meta.degree(); ++i) {
+      callback(static_cast<VertexTopologyID>(*begin++));
+    }
+  }
+
+  /*
    * Sort the outgoing edges for the given vertex.
    */
   void sortEdges(VertexTopologyID node) {

--- a/libgalois/test/graph-compile-lscsr.cpp
+++ b/libgalois/test/graph-compile-lscsr.cpp
@@ -84,6 +84,16 @@ int main() {
     GALOIS_ASSERT(g.getEdgeDst(handle) == g.getEdgeData(handle));
   }
 
+  // check for_each_edge
+  {
+    uint64_t current_edge = 1;
+    g.for_each_edge(0, [&current_edge](uint64_t dst) {
+      GALOIS_ASSERT(dst == current_edge);
+      current_edge++;
+    });
+    GALOIS_ASSERT(current_edge == 4);
+  }
+
   uint64_t eight = g.addVertexTopologyOnly();
   GALOIS_ASSERT(eight == 8);
 


### PR DESCRIPTION
Provides faster iteration over outgoing edges if only the `VertexTopologyID` of the destination edge is needed.