### PR TITLE
change largevector to not pre-populate mapping

### DIFF
--- a/libgalois/include/galois/LargeVector.h
+++ b/libgalois/include/galois/LargeVector.h
@@ -65,7 +65,8 @@ private:
     size_t const mmap_size =
         std::max(m_mappings.front().second * 2, m_capacity * sizeof(T));
 
-    m_data = static_cast<T*>(mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, m_fd, 0));
+    m_data = static_cast<T*>(
+        mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, m_fd, 0));
     if (m_data == MAP_FAILED)
       throw std::runtime_error(std::string("mmap failed: ") +
                                std::strerror(errno));

--- a/libgalois/include/galois/LargeVector.h
+++ b/libgalois/include/galois/LargeVector.h
@@ -65,8 +65,7 @@ private:
     size_t const mmap_size =
         std::max(m_mappings.front().second * 2, m_capacity * sizeof(T));
 
-    m_data = static_cast<T*>(mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE,
-                                  MAP_SHARED | MAP_POPULATE, m_fd, 0));
+    m_data = static_cast<T*>(mmap(nullptr, mmap_size, PROT_READ | PROT_WRITE, MAP_SHARED, m_fd, 0));
     if (m_data == MAP_FAILED)
       throw std::runtime_error(std::string("mmap failed: ") +
                                std::strerror(errno));

--- a/libgalois/test/large-vector.cpp
+++ b/libgalois/test/large-vector.cpp
@@ -69,7 +69,7 @@ int main() {
     the_vector.resize(0);
     GALOIS_ASSERT(num_destructed == max_cap);
     GALOIS_ASSERT(addr == &the_vector[max_cap]);
-    
+
     // this should not actually allocate memory!
     galois::LargeVector<char> huge(1ul << 40);
     huge[0] = 0;

--- a/libgalois/test/large-vector.cpp
+++ b/libgalois/test/large-vector.cpp
@@ -69,6 +69,10 @@ int main() {
     the_vector.resize(0);
     GALOIS_ASSERT(num_destructed == max_cap);
     GALOIS_ASSERT(addr == &the_vector[max_cap]);
+    
+    // this should not actually allocate memory!
+    galois::LargeVector<char> huge(1ul << 40);
+    huge[0] = 0;
   }
 
   return 0;


### PR DESCRIPTION
We are exploding the RSS by pre-populating `LargeVector`s for large graphs, which requires they be allocated physical memory at the time of creation.